### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## CoreDataOperation
-[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)  [![Cocoapods compatible](https://img.shields.io/cocoapods/v/CoreDataOperation.svg)](https://cocoapods.org) [![Cocoapods compatible](https://img.shields.io/cocoapods/p/CoreDataOperation.svg)](https://cocoapods.org)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)  [![CocoaPods compatible](https://img.shields.io/cocoapods/v/CoreDataOperation.svg)](https://cocoapods.org) [![CocoaPods compatible](https://img.shields.io/cocoapods/p/CoreDataOperation.svg)](https://cocoapods.org)
 
 CoreDataOperation is a fast, safe, flexible operation for updating your core data models. It supports the latest Swift 2.1 syntax, and does all its work in a background managed object context.
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
